### PR TITLE
Added new Collector and new ResultDatabase. Abstraction of ResultDatabase functionality.

### DIFF
--- a/src/main/scala/fuel/func/Experiment.scala
+++ b/src/main/scala/fuel/func/Experiment.scala
@@ -35,7 +35,7 @@ object Experiment {
           coll.rdb.save()
           opt.warnNonRetrieved
           if (opt('deleteOutputFile, true))
-            coll.rdb.f.delete()
+            coll.rdb.deleteArtifacts()
           None
         }
       }


### PR DESCRIPTION
In this commit added was a new Collector instance which only prints data to stdout. To achieve this, ResultDatabase was abstracted into a trait and two concrete implementations were introduced: ResultDatabaseFile (the same as before ResultDatabase) and ResultDatabasePlain(stores data and prints them on stdout when save is requested).

Some things may be perhaps optimized codewise, especially in Collectors (redundancy of code).