### PR TITLE
Added more general steady-state EA; some small fixes.

### DIFF
--- a/src/main/scala/fuel/func/EA.scala
+++ b/src/main/scala/fuel/func/EA.scala
@@ -12,9 +12,8 @@ trait IterativeSearch[S] extends Function1[S, S] {
   def iter: S => S
   def terminate: Seq[S => Boolean]
   protected val it = CallCounter(identity[S])
-  def algorithm = Iteration(iter andThen it)(terminate) andThen epilogue
+  def algorithm = Iteration(iter andThen it)(terminate)
   def apply(s: S) = algorithm(s)
-  def epilogue: S => S = (s => { println("Run finished."); s})
 }
 
 /**
@@ -49,7 +48,8 @@ abstract class EACore[S, E](moves: Moves[S], evaluation: Evaluation[S, E],
   def evaluate = evaluation andThen report
   override def terminate = Termination(stop).+:(Termination.MaxIter(it))
   def report = (s: StatePop[(S, E)]) => { println(f"Gen: ${it.count}"); s }
-  def apply() = (initialize andThen algorithm)()
+  def apply() = epilogue((initialize andThen algorithm)())
+  def epilogue: StatePop[(S, E)] => StatePop[(S, E)] = s => { println("Run finished."); s}
 }
 
 /**

--- a/src/main/scala/fuel/func/EA.scala
+++ b/src/main/scala/fuel/func/EA.scala
@@ -12,8 +12,9 @@ trait IterativeSearch[S] extends Function1[S, S] {
   def iter: S => S
   def terminate: Seq[S => Boolean]
   protected val it = CallCounter(identity[S])
-  def algorithm = Iteration(iter andThen it)(terminate)
+  def algorithm = Iteration(iter andThen it)(terminate) andThen epilogue
   def apply(s: S) = algorithm(s)
+  def epilogue: S => S = (s => { println("Run finished."); s})
 }
 
 /**

--- a/src/main/scala/fuel/util/Options.scala
+++ b/src/main/scala/fuel/util/Options.scala
@@ -18,7 +18,7 @@ trait Options {
   def warnNonRetrieved = {
     val nonRetrieved = allOptions.toList.diff(retrievedOptions.toList)
     if (nonRetrieved.nonEmpty)
-      println("WARNING: The following options have been set but not retrievied:\n" +
+      println("WARNING: The following options have been set but not retrieved:\n" +
         nonRetrieved.mkString("\n"))
   }
 

--- a/src/main/scala/fuel/util/Tools.scala
+++ b/src/main/scala/fuel/util/Tools.scala
@@ -3,7 +3,6 @@ package fuel.util
 import scala.tools.reflect.ToolBox
 import scala.reflect.runtime.{ currentMirror => cm }
 import scala.reflect.runtime.{currentMirror => cm}
-import scala.collection.immutable.Seq
 
 object Combinations {
   // Generates all nonempty n-ary combinations with replacement of elements from elems


### PR DESCRIPTION
The line "import scala.collection.immutable.Seq" turned out to be very problematic. In swim generally immutable.Seq was very common in interfaces, while in fuel the default scala.collection.Seq was used. This may lead to some very annoying situations when covariance and contravariance are involved.

Definitely swim and fuel needs to be consistent in this regard. I opted for more general scala.collection.Seq, from which immutable version inherits (as well as a mutable version). Thus that single import removed here. Much more to come in swim pull request coming soon.